### PR TITLE
Fixes link to Contributing guide in footer

### DIFF
--- a/src/data/index.json
+++ b/src/data/index.json
@@ -3,7 +3,7 @@
   "title": "Google Fonts + 日本語 早期アクセス • Google Fonts + Japanese Early Access",
   "description": "As Google makes progress on supporting Japanese web typography, we invite designers and developers to experiment with these Japanese web fonts now available from Google Fonts Early Access.",
   "url": "https://googlefonts.github.io/japanese",
-  "repository": "https://github.com/googlefonts/googlefonts.github.io/japanese",
+  "repository": "https://github.com/googlefonts/japanese",
   "baseurl": "",
   "action": "http://example.com",
   "og": {


### PR DESCRIPTION
The link to the Contributing guide in the footer of the site is broken, this fixes it by correcting repository URL in the metadata.