### PR TITLE
Adds sidebar arrow visual hint

### DIFF
--- a/src/components/SidebarColophon.js
+++ b/src/components/SidebarColophon.js
@@ -6,18 +6,24 @@ import Swipeable from 'react-swipeable';
 class SidebarArrow extends React.Component {
   render () {
     const self = this;
-    var className = 'py2 speak-none'
+    var className = 'pb2 speak-none select-none';
 
     if (self.props.visible === false) {
-      className += ' hide'
+      className += ' hide';
     }
 
     return (
       <div className={ className } aria-label="hidden">
         <span className="inline-block" style={{
           transform: 'rotate(' + self.props.deg + 'deg)',
-          transition: 'transform 0.66s 0.3s ease-in-out'
-        }}>⬆</span>
+          transition: 'transform 0.5s 0.15s ease-in-out'
+        }}>
+          {/* Apache 2.0 via https://design.google.com/icons/#ic_arrow_forward */}
+          <svg height="24" viewBox="0 0 24 24" width="24">
+            <path d="M0 0h24v24H0z" fill="none" />
+            <path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z" fill="inherit" />
+          </svg>
+        </span>
       </div>
     );
   }
@@ -25,7 +31,7 @@ class SidebarArrow extends React.Component {
 
 SidebarArrow.defaultProps = {
   visible: false,
-  deg: 90
+  deg: 0
 }
 
 class SidebarColophon extends React.Component {
@@ -100,10 +106,10 @@ class SidebarColophon extends React.Component {
                 onSwipedRight={self.props.onSwipedRight}>
               <div className="right col-12 md-col-12 ds-sidebar md-ds-none">
                 <div className={'h5 md-h4 animate-bg bg-' + self.props.backgroundColor} style={{height: 100 + 'vh'}}>
-                <div className={'p2 md-p3 animate-bg transition-color transition-sidebar ' + (self.props.backgroundColor === 'white' ? 'bg-white' : 'bg-lighten-3') + ' ' + ((self.props.backgroundColor === 'black' || self.props.backgroundColor === 'gray') ? 'white' : '')}
+                <div className={'p2 md-p3 animate-bg transition-color transition-sidebar ' + (self.props.backgroundColor === 'white' ? 'bg-white' : 'bg-lighten-3') + ' ' + ((self.props.backgroundColor === 'black' || self.props.backgroundColor === 'gray') ? 'white fill-white' : '')}
                      style={{minHeight: 100 + 'vh'}}>
 
-                  <SidebarArrow visible={!sidebarLargeScreen} deg={self.props.show ? 270 : -270} />
+                  <SidebarArrow visible={!sidebarLargeScreen} deg={self.props.show ? 540 : 0} />
 
                   <h3 className="border-top pt2 onum pnum inline-block mt0 font-weight-600">{fontNameHeading}{fontNameEn}</h3>
 

--- a/src/components/SidebarColophon.js
+++ b/src/components/SidebarColophon.js
@@ -3,6 +3,31 @@ import {StickyContainer, Sticky} from 'react-sticky';
 import CodeBlock from '../components/CodeBlock';
 import Swipeable from 'react-swipeable';
 
+class SidebarArrow extends React.Component {
+  render () {
+    const self = this;
+    var className = 'py2 speak-none'
+
+    if (self.props.visible === false) {
+      className += ' hide'
+    }
+
+    return (
+      <div className={ className } aria-label="hidden">
+        <span className="inline-block" style={{
+          transform: 'rotate(' + self.props.deg + 'deg)',
+          transition: 'transform 0.66s 0.3s ease-in-out'
+        }}>⬆</span>
+      </div>
+    );
+  }
+}
+
+SidebarArrow.defaultProps = {
+  visible: false,
+  deg: 90
+}
+
 class SidebarColophon extends React.Component {
   render() {
     const self = this;
@@ -13,11 +38,12 @@ class SidebarColophon extends React.Component {
     var codeBlock = '';
     var sidebarStyles = {};
     var fontNameHeading = font.name.ja;
+    var sidebarLargeScreen = self.props.viewport.width > self.props.sidebarMaxWidth
 
     var fontNameEn = (font.name.ja === font.name.en) ? <span className="block speak-none">&nbsp;</span> : <span lang="en" className="block font-weight-400 muted">{font.name.en}</span>;
     var fontDesignerNameEn = (font.designer.name.ja === font.designer.name.en) ? '' : <span lang="en" className="muted"> {font.designer.name.en}</span>;
 
-    if (self.props.viewport.width > self.props.sidebarMaxWidth) {
+    if (sidebarLargeScreen) {
       sidebarStyles.left = 0;
     } else {
       sidebarStyles.left = (self.props.show ? 25 : 83.3333333) + '%';
@@ -76,6 +102,8 @@ class SidebarColophon extends React.Component {
                 <div className={'h5 md-h4 animate-bg bg-' + self.props.backgroundColor} style={{height: 100 + 'vh'}}>
                 <div className={'p2 md-p3 animate-bg transition-color transition-sidebar ' + (self.props.backgroundColor === 'white' ? 'bg-white' : 'bg-lighten-3') + ' ' + ((self.props.backgroundColor === 'black' || self.props.backgroundColor === 'gray') ? 'white' : '')}
                      style={{minHeight: 100 + 'vh'}}>
+
+                  <SidebarArrow visible={!sidebarLargeScreen} deg={self.props.show ? 270 : -270} />
 
                   <h3 className="border-top pt2 onum pnum inline-block mt0 font-weight-600">{fontNameHeading}{fontNameEn}</h3>
 

--- a/src/css/module/_animate.scss
+++ b/src/css/module/_animate.scss
@@ -73,7 +73,7 @@
 }
 
 .transition-color {
-  transition: color 0.33s cubic-bezier(0.17, 0.67, 0.83, 0.67);
+  transition: color 0.33s cubic-bezier(0.17, 0.67, 0.83, 0.67), fill 0.33s cubic-bezier(0.17, 0.67, 0.83, 0.67);
 }
 
 .transition-sidebar {


### PR DESCRIPTION
For #2. When the sidebar is docked, an arrow will be present as a visual hint the sidebar can be opened. (You can still tap or swipe, and tapping on this icon has the same effect as tapping on the sidebar.)

![googlefonts-sidebar-arrow](https://cloud.githubusercontent.com/assets/1581276/19498209/a12f3808-9544-11e6-8472-5bbf486b7d26.gif)

The SVG also changes colour with the text as you scroll. The animation is much smoother than in the gif.